### PR TITLE
Revert "Change start-date to event-date for timetable datasets"

### DIFF
--- a/bin/generate-timetable-data/generate_local_plan_timetable.py
+++ b/bin/generate-timetable-data/generate_local_plan_timetable.py
@@ -468,11 +468,11 @@ def process_prototype_data(df_proto, df_vls_processed, lookup_dic):
     # Rename columns
     df_proto_melted = df_proto_melted.rename(columns={
         'variable': 'plan-event',
-        'value': 'event-date'
+        'value': 'start-date'
     })
 
     # Filter for rows with dates
-    df_proto_events = df_proto_melted.loc[df_proto_melted['event-date'].notna()].reset_index(drop=True)
+    df_proto_events = df_proto_melted.loc[df_proto_melted['start-date'].notna()].reset_index(drop=True)
 
     return df_proto_events
 
@@ -488,7 +488,7 @@ def merge_with_local_plans(df_proto_events, df_lp):
 
     # Group by common attributes to handle joint plans
     group_cols = ['name', 'period-start-year', 'period-end-year', 'document-url',
-                  'plan-event', 'event-date']
+                  'plan-event', 'start-date']
 
     df_proto_consolidated = df_proto_events.drop(['local-authority-code'], axis=1).groupby(
         group_cols, as_index=False
@@ -600,7 +600,7 @@ def merge_with_local_plans(df_proto_events, df_lp):
 
         # Try adoption date matching for plan-adopted events
         local_plan_event = df_proto_merged.loc[idx, 'plan-event']
-        start_date = df_proto_merged.loc[idx, 'event-date']
+        start_date = df_proto_merged.loc[idx, 'start-date']
 
         if local_plan_event == 'plan-adopted' and pd.notna(start_date):
             # Format adoption date as YYYY-MM-DD string
@@ -755,7 +755,7 @@ def generate_priority_lpas_events():
                 'name': "Emerging new local plan",
                 'local-plan': f"{slugify(lpa_name)}-new-local-plan",
                 'plan-event': event,
-                'event-date': None,
+                'start-date': None,
                 'entry-date': datetime.now().strftime('%Y-%m-%d'),
                 'notes': "Placeholder to help the authority provide their data",
             })
@@ -777,9 +777,9 @@ def export_timetable(df_final, output_path=None):
 
     print("Exporting timetable...")
 
-    # Format event-date column to date only (remove time component)
+    # Format start-date column to date only (remove time component)
     df_final = df_final.copy()
-    df_final['event-date'] = df_final['event-date'].apply(
+    df_final['start-date'] = df_final['start-date'].apply(
         lambda x: x.strftime('%Y-%m-%d') if pd.notna(x) and hasattr(x, 'strftime') else (x if isinstance(x, str) else '')
     )
     df_final = df_final.sort_values('local-plan')
@@ -814,7 +814,7 @@ def main():
     print(f"  - Merged data: {len(df_proto_merged)} rows")
 
     # Create timetable from merged data
-    df_timetable_final = df_proto_merged[['reference', 'local-plan', 'plan-event', 'event-date']].copy()
+    df_timetable_final = df_proto_merged[['reference', 'local-plan', 'plan-event', 'start-date']].copy()
     df_timetable_final['entry-date'] = datetime.now().strftime('%Y-%m-%d')
 
     # Generate priority LPAs events

--- a/bin/generate-timetable-data/generate_mineral_waste_timetable.py
+++ b/bin/generate-timetable-data/generate_mineral_waste_timetable.py
@@ -1705,7 +1705,7 @@ mineral_timetable = melted_df[melted_df['type'].isin(['M', 'M;W'])].copy()
 mineral_timetable = mineral_timetable.sort_values(['curie-organisations', 'name', 'local-plan-event', 'start-date']).reset_index(drop=True)
 # Select and reorder columns
 mineral_timetable = mineral_timetable[['reference', 'local-plan', 'local-plan-event', 'start-date', 'entry-date']].copy()
-mineral_timetable = mineral_timetable.rename(columns={'local-plan':'minerals-plan', 'local-plan-event': 'plan-event', 'start-date': 'event-date'})
+mineral_timetable = mineral_timetable.rename(columns={'local-plan':'minerals-plan', 'local-plan-event': 'plan-event'})
 # Deduplicate on (minerals-plan, plan-event) keeping the first (earliest) occurrence
 mineral_timetable = mineral_timetable.drop_duplicates(subset=['minerals-plan', 'plan-event'], keep='first').reset_index(drop=True)
 mineral_timetable_file = 'dataset/mineral-plan-timetable.csv'
@@ -1717,7 +1717,7 @@ waste_timetable = melted_df[melted_df['type'].isin(['W', 'M;W'])].copy()
 waste_timetable = waste_timetable.sort_values(['curie-organisations', 'name', 'local-plan-event', 'start-date']).reset_index(drop=True)
 # Select and reorder columns
 waste_timetable = waste_timetable[['reference', 'local-plan', 'local-plan-event', 'start-date', 'entry-date']].copy()
-waste_timetable = waste_timetable.rename(columns={'local-plan':'waste-plan', 'local-plan-event': 'plan-event', 'start-date': 'event-date'})
+waste_timetable = waste_timetable.rename(columns={'local-plan':'waste-plan', 'local-plan-event': 'plan-event'})
 # Deduplicate on (waste-plan, plan-event) keeping the first (earliest) occurrence
 waste_timetable = waste_timetable.drop_duplicates(subset=['waste-plan', 'plan-event'], keep='first').reset_index(drop=True)
 waste_timetable_file = 'dataset/waste-plan-timetable.csv'

--- a/dataset/local-plan-timetable.csv
+++ b/dataset/local-plan-timetable.csv
@@ -1,4 +1,4 @@
-reference,local-plan,plan-event,event-date,entry-date,name,notes
+reference,local-plan,plan-event,start-date,entry-date,name,notes
 adur-district-council-local-plan-2011-plan-adopted,adur-district-council-local-plan-2011,plan-adopted,2017-12-14,2026-03-30,,
 adur-district-council-local-plan-2011-planning-inspectorate-found-sound,adur-district-council-local-plan-2011,planning-inspectorate-found-sound,2017-09-29,2026-03-30,,
 adur-district-council-local-plan-2011-reg-19-publication-local-plan-published,adur-district-council-local-plan-2011,reg-19-publication-local-plan-published,2016-03-31,2026-03-30,,

--- a/dataset/mineral-plan-timetable.csv
+++ b/dataset/mineral-plan-timetable.csv
@@ -1,4 +1,4 @@
-reference,minerals-plan,plan-event,event-date,entry-date
+reference,minerals-plan,plan-event,start-date,entry-date
 bdf-lut-cbf-mineral-waste-plan-2014-plan-adopted,bdf-lut-cbf-mineral-waste-plan-2014,plan-adopted,2014-01-30,2026-01-29
 bdf-lut-cbf-mineral-waste-plan-2014-planning-inspectorate-found-sound,bdf-lut-cbf-mineral-waste-plan-2014,planning-inspectorate-found-sound,2013-10-04,2026-01-29
 bdf-lut-cbf-mineral-waste-plan-2014-reg-19-publication-local-plan-published,bdf-lut-cbf-mineral-waste-plan-2014,reg-19-publication-local-plan-published,2011-12-05,2026-01-29

--- a/dataset/waste-plan-timetable.csv
+++ b/dataset/waste-plan-timetable.csv
@@ -1,4 +1,4 @@
-reference,waste-plan,plan-event,event-date,entry-date
+reference,waste-plan,plan-event,start-date,entry-date
 bas-bst-nsm-sgc-waste-plan-2011-plan-adopted,bas-bst-nsm-sgc-waste-plan-2011,plan-adopted,2011-03-25,2026-01-29
 bas-bst-nsm-sgc-waste-plan-2011-planning-inspectorate-found-sound,bas-bst-nsm-sgc-waste-plan-2011,planning-inspectorate-found-sound,2011-02-03,2026-01-29
 bas-bst-nsm-sgc-waste-plan-2011-reg-19-publication-local-plan-published,bas-bst-nsm-sgc-waste-plan-2011,reg-19-publication-local-plan-published,2010-01-04,2026-01-29


### PR DESCRIPTION
Reverts digital-land/local-plan-extractor#361

We've realised changing the column name here hasn't fully removed the facts from the `start-date` column in the platform's plan-timetable.csv dataset.

So I am reverting the changes, and will instead update the config repo [column.csv](https://github.com/digital-land/config/blob/main/pipeline/local-plan/column.csv) file instead, to map the column from `start-date` to `event-date`.